### PR TITLE
Fixing broken archive build.

### DIFF
--- a/bin/stub.php
+++ b/bin/stub.php
@@ -1,3 +1,0 @@
-<?php
-
-include 'structure.php';

--- a/box.json
+++ b/box.json
@@ -1,7 +1,7 @@
 {
-	"files": ["structure.php", "bin/stub.php"],
+	"files": ["structure.php"],
 	"output": "bin/wfb.phar",
 	"stub": true,
-	"main": "bin/stub.php",
+	"main": "structure.php",
 	"chmod": "0755"
 }

--- a/structure.php
+++ b/structure.php
@@ -123,7 +123,7 @@ class Structure
 
 echo "Starting\n";
 
-$rootFolder = isset($argv[1]) ? $argv[1] : __DIR__;
+$rootFolder = isset($argv[1]) ? $argv[1] : getcwd();
 $depth = isset($argv[2]) ? $argv[2] : 0;
 $structure = new Structure();
 $data = $structure->buildStructure($rootFolder, $depth);

--- a/structure.php
+++ b/structure.php
@@ -34,8 +34,13 @@ class Structure
     function buildStructure($rootFolder, $depth)
     {
         self::$depth = $depth;
+        $structure = [];
 
-        return $this->_recursiveRead(realpath($rootFolder));
+        if (($path = realpath($rootFolder)) !== false) {
+            $structure = $this->_recursiveRead($path);
+        }
+
+        return $structure;
     }
 
     private function _recursiveRead($directory)


### PR DESCRIPTION
The following things were done to get a working build:
- Changed `__DIR__` to `getcwd()` since `__DIR__` will refer to inside the archive and not the current working directory
- Changed main script to `structure.php`
- Removed `stub.php`
- Checking for `false` when using `realpath()` to prevent iteration through root directory (`/`)
